### PR TITLE
Python version should be taken from sys.version_info

### DIFF
--- a/ordbok/__init__.py
+++ b/ordbok/__init__.py
@@ -4,7 +4,7 @@ import sys
 
 
 def is_str_or_unicode(s):
-    if sys.version < '3':
+    if sys.version_info[0] >= 3:
         return isinstance(s, basestring)
     else:
         return isinstance(s, str)


### PR DESCRIPTION
Python version information should be taken from `sys.version_info`, not `sys.version` (see https://docs.python.org/2/library/sys.html#sys.version_info). There is no guarantee the string `sys.version` will start with the version number in all Python interpreters.
