### PR TITLE
refactor the flask-helper and update documentation for more general use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ app.config.load()
 
 Then, in your app root path, create a directory `config` and add two files `config.yml` and `local_config.yml`. See [Usage](#usage) for more detailed usage and [Example](#examples) for an example YAML configuration.
 
+The `Flask` object here is whatever version you have install locally (`ordbok.flask_helper` imports `Flask` directly). Regardless, importing `Flask` from `ordbok` does feel a little weird, and if you prefer, you can installed do something to the effect of:
+
+```
+from flask import Flask
+from ordbok.flask_helper import OrdbokFlaskConfig, make_config
+Flask.config_class = OrdbokFlaskConfig
+Flask.make_config = make_config
+app = Flask(__name__)
+app.config.load()
+```
+
+If you look at `ordbok.flask_helper`, this is all that happens to the `Flask` object that's importable. It's very importand that `Flask.make_config` is overridden before the `app` is initialized as `make_config` is called from the initializer.
+
 ## Usage
 
 See [Quickstart](#quickstart) for getting initially setup.

--- a/ordbok/flask_helper.py
+++ b/ordbok/flask_helper.py
@@ -18,15 +18,17 @@ class OrdbokFlaskConfig(BaseConfig, Ordbok):
         return self.root_path
 
 
+def make_config(self, instance_relative=False):
+    root_path = self.root_path
+    if instance_relative:
+        root_path = self.instance_path
+    return self.config_class(root_path, self.default_config)
+
+
 class Flask(BaseFlask):
     """
     Extened version of `Flask` that implements the custom config class
     defined above.
     """
     config_class = OrdbokFlaskConfig
-
-    def make_config(self, instance_relative=False):
-        root_path = self.root_path
-        if instance_relative:
-            root_path = self.instance_path
-        return self.config_class(root_path, self.default_config)
+    make_config = make_config


### PR DESCRIPTION
Update so that importing `Flask` directly from `ordbok` isn't required (but the option is still available.)
